### PR TITLE
Upgrade pip before running `pip3 install poetry`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,11 @@ RUN locale-gen ja_JP.UTF-8
 WORKDIR /work
 COPY ./pyproject.toml ./pyproject.toml
 COPY ./poetry.lock    ./poetry.lock
-RUN  pip3 install poetry
-RUN  poetry install
+
+# Python
+RUN pip3 install -U pip
+RUN pip3 install poetry
+RUN poetry install
 
 # MeCab
 RUN apt update -y && \


### PR DESCRIPTION
`docker build` fail with the following message.

```
Collecting cryptography>=2.0 (from SecretStorage>=3.2; sys_platform == "linux"->keyring<22.0.0,>=21.2.0; python_version >= "3.6" and python_version < "4.0"->poetry)
  Downloading https://files.pythonhosted.org/packages/06/ed/cb79cc94ec58d9d92557238fc6c629cd6e07d72334d2de556aecc2211370/cryptography-3.4.1.tar.gz (544kB)
    Complete output from command python setup.py egg_info:
    
            =============================DEBUG ASSISTANCE==========================
            If you are seeing an error here please try the following to
            successfully install cryptography:
    
            Upgrade to the latest pip and try again. This will fix errors for most
            users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
            =============================DEBUG ASSISTANCE==========================
    
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-6twl32_m/cryptography/setup.py", line 14, in <module>
        from setuptools_rust import RustExtension
    ModuleNotFoundError: No module named 'setuptools_rust'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-6twl32_m/cryptography/
The command '/bin/sh -c pip3 install poetry' returned a non-zero code: 1
```

Upgrading `pip3` before running `pip3 install poetry` fixes the problem.

ref. https://github.com/openshift/assisted-test-infra/pull/496