### PR TITLE
Specify -M for transfer learning in dependency parsing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,8 @@ RUN wget "https://drive.google.com/uc?export=download&id=${CRFPP}" -O CRF++-0.58
       && make install
 
 # CaboCha
+WORKDIR /tmp
+RUN wget https://raw.githubusercontent.com/taku910/cabocha/a5d55a3c304a34bfcea170c30bcc9fcd4a62504f/model/dep.ipa.txt
 RUN wget --save-cookies=/tmp/cookie "https://drive.google.com/uc?export=download&id=${CABOCHA}" > /dev/null \
       && wget --load-cookies=/tmp/cookie "https://drive.google.com/uc?export=download&confirm=$(awk '/_warning_/ {print $NF}' /tmp/cookie)&id=${CABOCHA}" -O cabocha-0.69.tar.bz2 \
       && tar jxf cabocha-0.69.tar.bz2 && cd cabocha-0.69 \

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,12 @@ eval: mecab-eval pwner-eval cabocha-eval
 split:
 	poetry run python bin/split_dataset.py --corpus-dir cpc1.0 --output-dir outputs --proportion 8:1:1
 
+split-summary:
+	make split
+	poetry run python bin/summary.py --corpus-root outputs/train
+	poetry run python bin/summary.py --corpus-root outputs/valid
+	poetry run python bin/summary.py --corpus-root outputs/test
+
 mecab:
 	poetry run python bin/build_mecab.py --data-dir outputs/train --output-dir outputs/mecab
 	poetry run python bin/build_mecab.py --data-dir outputs/valid --output-dir outputs/mecab
@@ -94,7 +100,7 @@ pwner-learn:
 
 cabocha-learn:
 	# train
-	`cabocha-config --libexecdir`/cabocha-learn outputs/cabocha/cabocha.train outputs/cabocha/cookpad.cabocha
+	`cabocha-config --libexecdir`/cabocha-learn outputs/cabocha/cabocha.train outputs/cabocha/cookpad.cabocha -M /tmp/dep.ipa.txt
 	# infer
 	cabocha -I2 -f1 \
 		< outputs/cabocha/testb.sent \


### PR DESCRIPTION
This PR let CaboCha train a model with a pre-trained model.
In [Hiramatsu+, 2021], we trained a dependency parser in a transfer-learning manner.